### PR TITLE
multiqc

### DIFF
--- a/multiqc/main.nf
+++ b/multiqc/main.nf
@@ -1,0 +1,27 @@
+process RUN_MULTIQC {
+    cpus 1
+    memory "2.G"
+    time "30.m"
+    container "quay.io/biocontainers/multiqc:1.14--pyhdfd78af_0"
+    publishDir "results/${params.project}", mode: 'copy' 
+    // default mode would be tosymlink the files
+    
+    
+
+    input:
+    path(dirs) // list of fastqc dirs
+
+
+    output:
+    path("${output}/*")
+    // tuple val(sample), path(output) 
+
+
+    script:
+    output = "multiqc"
+    // output_1="fastqc_reports/${sample}_1_fastqc.zip"
+    """
+    mkdir -p $output
+    multiqc -f -o $output $dirs
+    """
+}

--- a/multiqc/meta.yml
+++ b/multiqc/meta.yml
@@ -1,0 +1,18 @@
+name: multiqc
+description:
+tools:
+  - multiqc:
+      description: Aggregate results from bioinformatics analyses across many
+       samples into a single report
+      homepage: https://multiqc.info/
+      docs: https://multiqc.info/docs/
+input:
+  - dirs:
+      type: path 
+      decsription: List of fastqc dirs to extract QC from
+output:
+  - output:
+      type: path
+      decsription: output directory with multiqc results
+authors: 
+  - "@samleenz"


### PR DESCRIPTION
Adding multiqc, as with fastqc just a direct port from [nf_rnaseq_exonAnalysis](https://github.com/samleenz/nf_rnaseq_exonAnalysis/blob/master/modules/run_multiqc.nf)

- This is a first version of multiqc support. Should extend it in the future to be able to hoover up other tools than fastqc but that's a future problem 