### PR TITLE
Salmon

### DIFF
--- a/salmon-index/main.nf
+++ b/salmon-index/main.nf
@@ -3,7 +3,7 @@ process RUN_SALMON_INDEX {
     memory "24.G"
     time "2.h"
     container "hub.docker.com/combinelab/salmon:1.10.0"
-    storeDir "$params.salmonDir"
+    storeDir "$params.store_dir"
 
     input:
     tuple val(tx_ver), path(txome)

--- a/salmon-index/main.nf
+++ b/salmon-index/main.nf
@@ -2,7 +2,7 @@ process RUN_SALMON_INDEX {
     cpus 4
     memory "24.G"
     time "2.h"
-    container "hub.docker.com/combinelab/salmon:1.10.0"
+    container "combinelab/salmon:1.10.0"
     storeDir "$params.store_dir"
 
     input:

--- a/salmon-index/main.nf
+++ b/salmon-index/main.nf
@@ -1,7 +1,7 @@
 process RUN_SALMON_INDEX {
     cpus 4
-    memory "24.G"
-    time "2.h"
+    memory "4.G"
+    time "10.m"
     container "combinelab/salmon:1.10.0"
     storeDir "$params.store_dir"
 

--- a/salmon-index/main.nf
+++ b/salmon-index/main.nf
@@ -1,0 +1,20 @@
+process RUN_SALMON_INDEX {
+    cpus 4
+    memory "24.G"
+    time "2.h"
+    container "hub.docker.com/combinelab/salmon:1.10.0"
+    storeDir "$params.salmonDir"
+
+    input:
+    tuple val(tx_ver), path(txome)
+
+    output:
+    path(idx)
+
+    script:
+    idx="salmon_index_${tx_ver}_1.10.0"
+    """
+    salmon index -t ${txome} -i ${idx}
+    """
+
+}

--- a/salmon-index/main.nf
+++ b/salmon-index/main.nf
@@ -6,7 +6,8 @@ process RUN_SALMON_INDEX {
     storeDir "$params.store_dir"
 
     input:
-    tuple val(tx_ver), path(txome)
+    val(tx_ver)
+    path(txome)
 
     output:
     path(idx)

--- a/salmon-index/meta.yml
+++ b/salmon-index/meta.yml
@@ -1,0 +1,21 @@
+name: salmon_index
+description: Generate the salmon index based on a transcriptome file
+tools:
+  - salmon:
+      homepage: https://combine-lab.github.io/salmon
+      docs: https://combine-lab.github.io/salmon
+input:
+  - tx_ver:
+      type: val
+      decsription: character that describes which transcriptome version is 
+        being used 
+  - txome:
+      type: path
+      decsription: Transcriptome file to index (*.fa.gz file)
+output:
+  - idx:
+      type: path 
+      decsription: Directory containing the salmon index,
+      name 
+authors: 
+  - "@samleenz"

--- a/salmon-quant/main.nf
+++ b/salmon-quant/main.nf
@@ -1,0 +1,31 @@
+process RUN_SALMON_QUANT {
+    cpus 4
+    memory "24.G"
+    time "2.h"
+    container "hub.docker.com/combinelab/salmon:1.10.0"
+    tag "$sample"
+
+    input:
+    tuple val(sample), path(reads)
+    path(salmon_idx)
+
+    output:
+    tuple(
+        path("${output}/quant.sf")
+        path("${output}/cmd_info.json")
+        path("${output}/aux_info")
+    )
+
+    script:
+    output="quant/${sample}_quant"
+    """
+    salmon quant \
+      -i ${salmon_idx} \
+      -l A \
+      -1 ${reads[0]} \
+      -2 ${reads[1]} \
+      -p ${task.cpus} \
+      -o ${output}
+    """
+
+}

--- a/salmon-quant/main.nf
+++ b/salmon-quant/main.nf
@@ -1,8 +1,8 @@
 process RUN_SALMON_QUANT {
     cpus 4
-    memory "24.G"
-    time "2.h"
-    container "hub.docker.com/combinelab/salmon:1.10.0"
+    memory "16.G"
+    time "1.h"
+    container "combinelab/salmon:1.10.0"
     tag "$sample"
 
     input:

--- a/salmon-quant/main.nf
+++ b/salmon-quant/main.nf
@@ -1,7 +1,7 @@
 process RUN_SALMON_QUANT {
     cpus 4
-    memory "16.G"
-    time "1.h"
+    memory "8.G"
+    time "30.m"
     container "combinelab/salmon:1.10.0"
     tag "$sample"
 

--- a/salmon-quant/meta.yml
+++ b/salmon-quant/meta.yml
@@ -1,0 +1,25 @@
+name: salmon_quant
+description: Generate counts using salmon pseudoalignment
+tools:
+  - salmon:
+      homepage: https://combine-lab.github.io/salmon
+      docs: https://combine-lab.github.io/salmon
+input:
+  - sample:
+      type: val 
+      decsription: Sample identifier
+  - reads:
+      type: path
+      decsription: Input fastq files, read 1 and read 2
+output:
+  - quant.sf:
+      type: path 
+      decsription: Plain text tsv containing quantification data for the sample
+  - cmd_info.json:
+      type: path 
+      decsription: json file with the command line parameters used
+  - aux_info:
+      type: path 
+      decsription: Directory containg additional info about the salmon run        
+authors: 
+  - "@samleenz"


### PR DESCRIPTION
Adding two modules, `salmon-index` and `salmon-quant` to allow for rnaseq quantification with salmon. Using the 'official' docker hub image instead of quay.io 

- Have tested these work, and as expected on milton
- I have no implemented any decoy-aware indexing with `salmon-index`, this may be worth including as in improvement down the line?
- currently default parameters for the quantification 
- as another note, not sure if we really need to list the 2nd / 3rd outputs explicitly for `salmon-quant`. Have a think about what might be required (for multiQC in particular I guess?) and update as required 