### PR TITLE
add npass input val channel to label outputfiles

### DIFF
--- a/star-align/main.nf
+++ b/star-align/main.nf
@@ -12,6 +12,7 @@ process RUN_STAR_ALIGN {
     path(index)
     val(read_len)
     path(junctions)
+    val(npass)
 
     output:
     tuple val(sample), path(alignment)
@@ -21,9 +22,9 @@ process RUN_STAR_ALIGN {
     script:
     // println(junctions)
 
-    alignment = "${sample}_Aligned.sortedByCoord.out.bam"
-    splice_junc = "${sample}_SJ.out.tab"
-    star_log = "${sample}_Log.final.out"
+    alignment = "${sample}_pass${npass}_Aligned.sortedByCoord.out.bam"
+    splice_junc = "${sample}_pass${npass}_SJ.out.tab"
+    star_log = "${sample}_pass${npass}_Log.final.out"
     overhang = read_len - 1
     pass2 = junctions.name != "NO_FILE" ? "--sjdbFileChrStartEnd ${junctions}" : ""
     // above, if the junctions input is default: make empty, otherwise add the junctions for 
@@ -34,7 +35,7 @@ process RUN_STAR_ALIGN {
          --readFilesIn ${reads[0]} ${reads[1]} \
          --outSAMtype BAM SortedByCoordinate \
          --readFilesCommand zcat \
-         --outFileNamePrefix ${sample}_ \
+         --outFileNamePrefix ${sample}_pass${npass}_ \
          --sjdbOverhang $overhang \
          --alignSJDBoverhangMin 1 \
          --alignSJoverhangMin 8 \


### PR DESCRIPTION
This pull request is a suggested way to address Nextflow's failure to cache the results of `STAR` align when using multiple passes.

A new input channel is specified, which is used to label the output file.